### PR TITLE
Fix/doc improvement (#40)

### DIFF
--- a/maturity-level-one/README.md
+++ b/maturity-level-one/README.md
@@ -29,7 +29,6 @@ Think about your operation URIs and make them as RESTy as possible – What we m
      - _`https://customer.contoso.com/api/v1/{controller}`_
      - _`https://api.domain.com/hr/v1/{controller}`_   
    - _Don't_
-     - _`https://order.contoso.com/api/v1/{controller}`_
      - _Avoid duplication - `https://api.contoso.com/api/customer/v1/{controller}`_
      - _No added value - `https://data.contoso.com/api/customer/v1/{controller}`_
 - **Use plural for collections of resources**
@@ -54,7 +53,7 @@ Think about your operation URIs and make them as RESTy as possible – What we m
    - Allows you to introduce new versions later one without breaking anything
    - Path versioning is the advised approach
      - _Example - `https://api.contoso.com/master-data/v1/items/{itemId}/components/{componentId}`_
-- **Data contract versioning is determined by using content-negotiation and custom media types**
+- **Data contract versioning is determined by [using content-negotiation and custom media types](https://github.com/Microsoft/aspnet-api-versioning/wiki/Versioning-by-Media-Type)**
    - _Example - `GET /items/H12652 Accept: application/vnd.mdm.v2+json`_
 
 ### Data Contracts


### PR DESCRIPTION
- Removed a contradictory example in the naming guidelines
- Add a link to an article that contains some more information about versioning by media-type